### PR TITLE
Replaced base64.encodestring() with base64.b64encode()

### DIFF
--- a/couchbase_collector.py
+++ b/couchbase_collector.py
@@ -74,7 +74,7 @@ class CouchbaseCollector(diamond.collector.Collector):
     if bucket is not None:
       url = url + bucket + '/stats'
 
-    auth_string = base64.encodestring('%s:%s' % (self.config['user'], self.config['passwd']))
+    auth_string = base64.b64encode('%s:%s' % (self.config['user'], self.config['passwd']))
 
     request = urllib2.Request(url);
     request.add_header("Authorization", "Basic %s" % auth_string)


### PR DESCRIPTION
encodestring() inserts a new line at the end of the string while b64encode() does a straight encoding. The collector, as it stands, fails due to the new line insert.